### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tree-sitter grammar for the [HCL](https://github.com/hashicorp/hcl/blob/main/hcl
 
 ## Try It Out
 
-Try the parser in the [playground](https://michahoffmann.github.io/tree-sitter-hcl/)
+Try the parser in the [playground](https://tree-sitter-grammars.github.io/tree-sitter-hcl/)
 
 ## Example
 


### PR DESCRIPTION
I was checking out the repo and noticed the playground link in the README was broken. It was updated in the repo description. I copied that link and put it in the README.