### PR TITLE
chore: Bump Rust version(s)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-hcl"
 description = "hcl grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.22.0"
 keywords = ["incremental", "parsing", "hcl"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/MichaHoffmann/tree-sitter-hcl"
@@ -15,7 +15,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.10"
+tree-sitter = ">=0.22.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-hcl"
 description = "hcl grammar for the tree-sitter parsing library"
-version = "0.22.0"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "hcl"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/MichaHoffmann/tree-sitter-hcl"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -7,6 +7,9 @@ fn main() {
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs");
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,21 +2,18 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(src_dir);
-    c_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
+    c_config.std("c11").include(src_dir);
+
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
 
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 
-    c_config.compile("parser");
-    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("tree-sitter-hcl");
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,13 +1,15 @@
-//! This crate provides hcl language support for the [tree-sitter][] parsing library.
+//! This crate provides Hcl language support for the [tree-sitter][] parsing library.
 //!
 //! Typically, you will use the [language][language func] function to add this language to a
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(&tree_sitter_hcl::language()).expect("Error loading hcl grammar");
+//! parser.set_language(&tree_sitter_hcl::language()).expect("Error loading Hcl grammar");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
@@ -35,10 +37,10 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -47,6 +49,6 @@ mod tests {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&super::language())
-            .expect("Error loading hcl language");
+            .expect("Error loading Hcl grammar");
     }
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_hcl::language()).expect("Error loading hcl grammar");
+//! parser.set_language(&tree_sitter_hcl::language()).expect("Error loading hcl grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -31,7 +31,7 @@ pub fn language() -> Language {
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
@@ -46,7 +46,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::language())
             .expect("Error loading hcl language");
     }
 }


### PR DESCRIPTION
Upstream base `tree-sitter` has seen some updates this now
incorporates.

It also bumps this crate's version. The scheme chosen is for the
Rust crate's version to be in lockstep with the `tree-sitter`
dependency. Looking at the major tree-sitter libraries,
this seems to be the general style chosen. For example:

- Python: https://github.com/tree-sitter/tree-sitter-python/blob/0dee05ef958ba2eae88d1e65f24b33cad70d4367/Cargo.toml
- TypeScript: https://github.com/tree-sitter/tree-sitter-typescript/blob/198d03553f43a45b92ac5d0ee167db3fec6a6fd6/Cargo.toml

The commit also adjust the Rust code to be
compatible (the `&'static` change was just a lint,
not a compile error). `cargo build` and `cargo
test` now pass.